### PR TITLE
Don't needed `progn` removed

### DIFF
--- a/init.el
+++ b/init.el
@@ -64,9 +64,8 @@
 (use-package ace-window
   :ensure t
   :init
-  (progn
-    (global-set-key [remap other-window] 'ace-window)
-    (custom-set-faces
-     '(aw-leading-char-face
-       ((t (:inherit ace-jump-face-foreground :height 3.0))))) 
-    ))
+  (global-set-key [remap other-window] 'ace-window)
+  (custom-set-faces
+   '(aw-leading-char-face
+     ((t (:inherit ace-jump-face-foreground :height 3.0))))
+   ))


### PR DESCRIPTION
I think that is more idiomatic way to use elisp and use-package.